### PR TITLE
Update runtime.txt

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.7
+python-3.9.4


### PR DESCRIPTION
python 3.7.7 not supported by heroku, use 3.9.4 instead (did not test if this breaks the bot, but atleast the build works)